### PR TITLE
Fixed exception when loading application from from pyinstaller exe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         pip install -r requirements.txt
 
     - name: Build with PyInstaller
-      run: pyinstaller --onefile --icon=source/icon.ico source/cqsaveeditor.py
+      run: pyinstaller --onefile --icon=source/icon.ico --add-data=source/icon.ico:. source/cqsaveeditor.py
 
     - name: Upload executable as artifact
       uses: actions/upload-artifact@v4
@@ -55,7 +55,7 @@ jobs:
       run: pip install pyinstaller
 
     - name: Build with PyInstaller
-      run: pyinstaller --onefile --icon=source/icon.ico source/cqsaveeditor.py
+      run: pyinstaller --onefile --icon=source/icon.ico --add-data=source/icon.ico:. source/cqsaveeditor.py
 
     - name: Upload executable as artifact
       uses: actions/upload-artifact@v4

--- a/source/cqsaveeditor.py
+++ b/source/cqsaveeditor.py
@@ -1040,7 +1040,14 @@ for tab in ("Quests",):
 
 # Menu, icon, mainloop
 create_menu()
-icon_path = os.path.join(BASE_DIR, 'icon.ico')
+
+# checking if the script is running from a pyinstaller generated exe or from loose script files
+
+if getattr(sys, 'frozen', False):
+    icon_path = os.path.join(sys._MEIPASS, 'icon.ico')
+else:
+    icon_path = os.path.join(BASE_DIR, 'icon.ico')
+
 root.iconbitmap(icon_path)
 apply_theme("dark" if dark_mode_enabled else "light")
 root.mainloop()


### PR DESCRIPTION
The pyinstaller generated binary fails to load due to it attempting to load icon file as a loose file from the same directory.

This PR does the following;

- introduces the "--add-data" parameter for pyinstaller to bundle the icon file as a resource
- checks the frozen flag (is the script running from a pyinstaller generated binary) and if so load from pyinstaller resources

This allows the executable to be fully portable without any loose file resources.